### PR TITLE
Add og:image tags for product overview pages

### DIFF
--- a/src-11ty/_includes/base.html
+++ b/src-11ty/_includes/base.html
@@ -11,6 +11,15 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="description" content="{{ description }}" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Open Graph meta tags -->
+    <meta property="og:title" content="{{ full_title }}" />
+    <meta property="og:description" content="{{ description }}" />
+    {%- if image %}
+    <meta property="og:image" content="https://toolbox.openhomefoundation.org{{ image }}" />
+    {%- endif %}
+    <meta property="og:type" content="website" />
+
     <link rel="stylesheet" href="/src/styles/main.css" />
   </head>
   <body class="wa-palette-shoelace wa-theme-shoelace">

--- a/src-11ty/home-assistant-connect-zbt-1/index.md
+++ b/src-11ty/home-assistant-connect-zbt-1/index.md
@@ -2,6 +2,7 @@
 layout: product-overview.html
 title: Home Assistant Connect ZBT-1
 description: Update firmware for your Connect ZBT-1 adapter
+image: /images/zbt1.jpg
 
 productTitle: Home Assistant Connect ZBT-1
 productSubtitle: Zigbee 3.0 USB adapter

--- a/src-11ty/home-assistant-connect-zwa-2/index.md
+++ b/src-11ty/home-assistant-connect-zwa-2/index.md
@@ -2,6 +2,7 @@
 layout: product-overview.html
 title: Home Assistant Connect ZWA-2
 description: Home Assistant Connect ZWA-2 - 800 series Z-Wave Long Range adapter
+image: /images/zwa2.webp
 
 productTitle: Home Assistant Connect ZWA-2
 productSubtitle: The ultimate way to connect Z-Wave devices to Home Assistant.

--- a/src-11ty/home-assistant-voice-preview-edition/index.md
+++ b/src-11ty/home-assistant-voice-preview-edition/index.md
@@ -2,6 +2,7 @@
 layout: product-overview.html
 title: Home Assistant Voice Preview Edition
 description: Home Assistant Voice Preview Edition - Local voice control for your smart home
+image: /images/voice.jpg
 
 productTitle: Home Assistant Voice Preview Edition
 productSubtitle: Local voice control for your smart home

--- a/src-11ty/improv/index.md
+++ b/src-11ty/improv/index.md
@@ -2,6 +2,7 @@
 layout: product-overview.html
 title: Improv Wi-Fi
 description: Connect devices to Wi-Fi via Bluetooth from your browser
+image: /images/improv.png
 
 productTitle: Improv Wi‑Fi
 productSubtitle: Provision Wi‑Fi for devices without a custom app


### PR DESCRIPTION
- Add image property to product frontmatter for ZBT-1, ZWA-2, Voice PE, and Improv
- Add Open Graph meta tags to base.html template
- Include og:title, og:description, og:image, and og:type tags
- Images are sourced from the product cards on the index page