### PR TITLE
Bump sl-web-tools to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "toolbox",
       "version": "0.0.0",
       "dependencies": {
-        "@nabucasa/sl-web-tools": "^0.11.0",
+        "@nabucasa/sl-web-tools": "^0.12.0",
         "improv-wifi-sdk": "^1.4.0"
       },
       "devDependencies": {
@@ -730,6 +730,15 @@
       "integrity": "sha512-ficsEARKnmmW5njugNYKipTm4SFnbik7CXtoencDZzmzo/dQ+2Q0bgkzJuoJP20Aj0F+izzJjOqsnkd6F/o1bw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
     "node_modules/@material/animation": {
       "version": "14.0.0-canary.53b3cad2f.0",
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.53b3cad2f.0.tgz",
@@ -952,46 +961,6 @@
         "tslib": "^2.0.1"
       }
     },
-    "node_modules/@material/mwc-base/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-base/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-base/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-base/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
     "node_modules/@material/mwc-button": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.27.0.tgz",
@@ -1003,46 +972,6 @@
         "@material/mwc-ripple": "^0.27.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-button/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-button/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-button/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-button/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/@material/mwc-circular-progress": {
@@ -1057,46 +986,6 @@
         "@material/theme": "=14.0.0-canary.53b3cad2f.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-circular-progress/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-circular-progress/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-circular-progress/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-circular-progress/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/@material/mwc-dialog": {
@@ -1116,46 +1005,6 @@
         "wicg-inert": "^3.0.0"
       }
     },
-    "node_modules/@material/mwc-dialog/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-dialog/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-dialog/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-dialog/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
     "node_modules/@material/mwc-floating-label": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@material/mwc-floating-label/-/mwc-floating-label-0.27.0.tgz",
@@ -1166,46 +1015,6 @@
         "@material/floating-label": "=14.0.0-canary.53b3cad2f.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-floating-label/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-floating-label/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-floating-label/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-floating-label/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/@material/mwc-formfield": {
@@ -1219,46 +1028,6 @@
         "@material/mwc-base": "^0.27.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-formfield/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-formfield/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-formfield/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-formfield/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/@material/mwc-icon": {
@@ -1284,86 +1053,6 @@
         "tslib": "^2.0.1"
       }
     },
-    "node_modules/@material/mwc-icon-button/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-icon-button/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-icon-button/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-icon-button/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
-    "node_modules/@material/mwc-icon/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-icon/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-icon/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-icon/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
     "node_modules/@material/mwc-line-ripple": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@material/mwc-line-ripple/-/mwc-line-ripple-0.27.0.tgz",
@@ -1374,46 +1063,6 @@
         "@material/line-ripple": "=14.0.0-canary.53b3cad2f.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-line-ripple/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-line-ripple/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-line-ripple/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-line-ripple/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/@material/mwc-linear-progress": {
@@ -1430,46 +1079,6 @@
         "tslib": "^2.0.1"
       }
     },
-    "node_modules/@material/mwc-linear-progress/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-linear-progress/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-linear-progress/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-linear-progress/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
     "node_modules/@material/mwc-notched-outline": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@material/mwc-notched-outline/-/mwc-notched-outline-0.27.0.tgz",
@@ -1481,46 +1090,6 @@
         "@material/notched-outline": "=14.0.0-canary.53b3cad2f.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-notched-outline/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-notched-outline/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-notched-outline/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-notched-outline/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/@material/mwc-radio": {
@@ -1537,46 +1106,6 @@
         "tslib": "^2.0.1"
       }
     },
-    "node_modules/@material/mwc-radio/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-radio/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-radio/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-radio/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
     "node_modules/@material/mwc-ripple": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.27.0.tgz",
@@ -1589,46 +1118,6 @@
         "@material/ripple": "=14.0.0-canary.53b3cad2f.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-ripple/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-ripple/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-ripple/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-ripple/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/@material/mwc-textfield": {
@@ -1647,46 +1136,6 @@
         "@material/textfield": "=14.0.0-canary.53b3cad2f.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/@material/mwc-textfield/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@material/mwc-textfield/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-textfield/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@material/mwc-textfield/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/@material/notched-outline": {
@@ -1840,9 +1289,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@nabucasa/sl-web-tools": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@nabucasa/sl-web-tools/-/sl-web-tools-0.11.0.tgz",
-      "integrity": "sha512-m6E/SDAiARhpyubZ5V0bqq1h0JF6fAkt+hw/QjSQY7GYknMZI6TO/1LXzYhPU3Tw/UIlz0mMnjK3MeqXqbT4QA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@nabucasa/sl-web-tools/-/sl-web-tools-0.12.0.tgz",
+      "integrity": "sha512-Edt1VT4O6wiv9RS4ZX2OgY1/EHTDd2331H1wKtgHjGdZHjwjlRnGr+7tlmxR8P8XKfzHvFYTCpYJuPyACalK+A==",
       "license": "MIT",
       "dependencies": {
         "@material/mwc-button": "^0.27.0",
@@ -1853,47 +1302,8 @@
         "@material/mwc-linear-progress": "^0.27.0",
         "@material/mwc-radio": "^0.27.0",
         "@mdi/js": "^7.1.96",
-        "lit": "^2.0.2"
-      }
-    },
-    "node_modules/@nabucasa/sl-web-tools/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/@nabucasa/sl-web-tools/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@nabucasa/sl-web-tools/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/@nabucasa/sl-web-tools/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
+        "lit": "^2.0.2",
+        "pyodide": "^0.29.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2262,6 +1672,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3277,46 +2693,6 @@
         "tslib": "^2.4.1"
       }
     },
-    "node_modules/improv-wifi-sdk/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/improv-wifi-sdk/node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/improv-wifi-sdk/node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/improv-wifi-sdk/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3444,18 +2820,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/jiti": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
-      "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -3536,6 +2900,37 @@
       "integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -3984,6 +3379,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pyodide": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.29.0.tgz",
+      "integrity": "sha512-ObIvsTmcrxAWKg+FT1GjfSdDmQc5CabnYe/nn5BCuhr9BVVITeQ24DBdZuG5B2tIiAZ9YonBpnDB7cmHZyd2Rw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@types/emscripten": "^1.41.4",
+        "ws": "^8.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/range-parser": {
@@ -4509,7 +3917,6 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:check": "npx prettier --check src/**/*"
   },
   "dependencies": {
-    "@nabucasa/sl-web-tools": "^0.11.0",
+    "@nabucasa/sl-web-tools": "^0.12.0",
     "improv-wifi-sdk": "^1.4.0"
   },
   "devDependencies": {

--- a/public/assets/manifests/zbt1.json
+++ b/public/assets/manifests/zbt1.json
@@ -1,47 +1,47 @@
 {
   "product_name": "Home Assistant Connect ZBT-1",
-  "baudrates": {
-    "bootloader": [
-      115200
-    ],
-    "cpc": [
-      460800,
-      115200,
-      230400
-    ],
-    "ezsp": [
-      115200,
-      460800
-    ],
-    "spinel": [
-      460800
-    ]
-  },
-  "usb_filters": [
-    {
-      "pid": 60000,
-      "vid": 4292
-    }
-  ],
-  "firmwares": [
-    {
-      "name": "Zigbee (EZSP)",
-      "url": "/assets/firmwares/skyconnect_zigbee_ncp_7.4.4.3.gbl",
-      "type": "ncp-uart-hw",
-      "version": "7.4.4.3"
-    },
-    {
-      "name": "OpenThread (RCP)",
-      "url": "/assets/firmwares/skyconnect_openthread_rcp_2.4.4.0_GitHub-7074a43e4_gsdk_4.4.4.gbl",
-      "type": "ot-rcp",
-      "version": "2.4.4.0"
-    },
-    {
-      "name": "Multiprotocol (deprecated)",
-      "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/RCPMultiPAN/beta/NabuCasa_SkyConnect_RCP_v4.3.2_rcp-uart-hw-802154_460800.gbl",
-      "type": "rcp-uart-802154",
-      "version": "4.3.2"
-    }
-  ],
+  "probe_methods": [{
+    "protocol": "bootloader",
+    "baudrate": 115200
+  }, {
+    "protocol": "ezsp",
+    "baudrate": 115200
+  }, {
+    "protocol": "spinel",
+    "baudrate": 460800
+  }, {
+    "protocol": "cpc",
+    "baudrate": 460800
+  }, {
+    "protocol": "cpc",
+    "baudrate": 115200
+  }, {
+    "protocol": "cpc",
+    "baudrate": 230400
+  }, {
+    "protocol": "router",
+    "baudrate": 115200
+  }],
+  "usb_filters": [{
+    "pid": 60000,
+    "vid": 4292
+  }],
+  "firmwares": [{
+    "name": "Zigbee (EZSP)",
+    "url": "/assets/firmwares/skyconnect_zigbee_ncp_7.4.4.3.gbl",
+    "type": "ncp-uart-hw",
+    "version": "7.4.4.3"
+  }, {
+    "name": "OpenThread (RCP)",
+    "url": "/assets/firmwares/skyconnect_openthread_rcp_2.4.4.0_GitHub-7074a43e4_gsdk_4.4.4.gbl",
+    "type": "ot-rcp",
+    "version": "2.4.4.0"
+  }, {
+    "name": "Multiprotocol (deprecated)",
+    "url": "https://raw.githubusercontent.com/NabuCasa/silabs-firmware/main/RCPMultiPAN/beta/NabuCasa_SkyConnect_RCP_v4.3.2_rcp-uart-hw-802154_460800.gbl",
+    "type": "rcp-uart-802154",
+    "version": "4.3.2"
+  }],
+  "bootloader_reset": [],
   "allow_custom_firmware_upload": true
 }

--- a/public/assets/manifests/zbt2.json
+++ b/public/assets/manifests/zbt2.json
@@ -9,9 +9,6 @@
   }, {
     "protocol": "spinel",
     "baudrate": 460800
-  }, {
-    "protocol": "router",
-    "baudrate": 115200
   }],
   "usb_filters": [{
     "pid": 16385,

--- a/public/assets/manifests/zbt2.json
+++ b/public/assets/manifests/zbt2.json
@@ -31,6 +31,6 @@
     "type": "ot-rcp",
     "version": "2.4.4.0"
   }],
-  "bootloader_reset": [],
+  "bootloader_reset": ["rts_dtr", "bootloader"],
   "allow_custom_firmware_upload": true
 }

--- a/public/assets/manifests/zbt2.json
+++ b/public/assets/manifests/zbt2.json
@@ -1,40 +1,36 @@
 {
   "product_name": "Home Assistant Connect ZBT-2",
-  "baudrates": {
-    "bootloader": [
-      115200
-    ],
-    "cpc": [],
-    "ezsp": [
-      460800
-    ],
-    "spinel": [
-      460800
-    ]
-  },
-  "usb_filters": [
-    {
-      "pid": 16385,
-      "vid": 12346
-    },
-    {
-      "pid": 33562,
-      "vid": 12346
-    }
-  ],
-  "firmwares": [
-    {
-      "name": "Zigbee (EZSP)",
-      "url": "/assets/firmwares/zbt2_zigbee_ncp_7.4.4.5.gbl",
-      "type": "ncp-uart-hw",
-      "version": "7.4.4.5"
-    },
-    {
-      "name": "OpenThread (RCP)",
-      "url": "/assets/firmwares/zbt2_openthread_rcp_2.4.4.0_GitHub-7074a43e4_gsdk_4.4.4.gbl",
-      "type": "ot-rcp",
-      "version": "2.4.4.0"
-    }
-  ],
+  "probe_methods": [{
+    "protocol": "bootloader",
+    "baudrate": 115200
+  }, {
+    "protocol": "ezsp",
+    "baudrate": 460800
+  }, {
+    "protocol": "spinel",
+    "baudrate": 460800
+  }, {
+    "protocol": "router",
+    "baudrate": 115200
+  }],
+  "usb_filters": [{
+    "pid": 16385,
+    "vid": 12346
+  }, {
+    "pid": 33562,
+    "vid": 12346
+  }],
+  "firmwares": [{
+    "name": "Zigbee (EZSP)",
+    "url": "/assets/firmwares/zbt2_zigbee_ncp_7.4.4.5.gbl",
+    "type": "ncp-uart-hw",
+    "version": "7.4.4.5"
+  }, {
+    "name": "OpenThread (RCP)",
+    "url": "/assets/firmwares/zbt2_openthread_rcp_2.4.4.0_GitHub-7074a43e4_gsdk_4.4.4.gbl",
+    "type": "ot-rcp",
+    "version": "2.4.4.0"
+  }],
+  "bootloader_reset": [],
   "allow_custom_firmware_upload": true
 }


### PR DESCRIPTION
Bump sl-web-tools to [0.12.0](https://github.com/NabuCasa/sl-web-tools/releases/tag/0.12.0). This release brings with it a new manifest JSON format, incorporates the latest release of universal-silabs-flasher, and bumps pyodide (migrating us from Python 3.9 to 3.13).

<img width="813" height="356" alt="image" src="https://github.com/user-attachments/assets/8cf2fbec-fc1f-4607-97c0-9d4ad33c4110" />
