### PR TITLE
Fix bootloader reset typo in ZBT-2 manifest

### DIFF
--- a/public/assets/manifests/zbt2.json
+++ b/public/assets/manifests/zbt2.json
@@ -28,6 +28,6 @@
     "type": "ot-rcp",
     "version": "2.4.4.0"
   }],
-  "bootloader_reset": ["rts_dtr", "bootloader"],
+  "bootloader_reset": ["rts_dtr", "baudrate"],
   "allow_custom_firmware_upload": true
 }


### PR DESCRIPTION
`bootloader` should be `baudrate`.