### PR TITLE
Bump sl-web-tools to 0.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "toolbox",
       "version": "0.0.0",
       "dependencies": {
-        "@nabucasa/sl-web-tools": "^0.12.0",
+        "@nabucasa/sl-web-tools": "^0.12.1",
         "improv-wifi-sdk": "^1.4.0"
       },
       "devDependencies": {
@@ -1289,9 +1289,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@nabucasa/sl-web-tools": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@nabucasa/sl-web-tools/-/sl-web-tools-0.12.0.tgz",
-      "integrity": "sha512-Edt1VT4O6wiv9RS4ZX2OgY1/EHTDd2331H1wKtgHjGdZHjwjlRnGr+7tlmxR8P8XKfzHvFYTCpYJuPyACalK+A==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@nabucasa/sl-web-tools/-/sl-web-tools-0.12.1.tgz",
+      "integrity": "sha512-JLYOcMKEgSRWV9I3IOIYOc5XT692s8hUWWqkpEuzOwUTPNF9FqVuwVpsT5bKipDCTQ33t3/hkCZxo7i12rbbAw==",
       "license": "MIT",
       "dependencies": {
         "@material/mwc-button": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:check": "npx prettier --check src/**/*"
   },
   "dependencies": {
-    "@nabucasa/sl-web-tools": "^0.12.0",
+    "@nabucasa/sl-web-tools": "^0.12.1",
     "improv-wifi-sdk": "^1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps sl-web-tools from 0.12.0 to 0.12.1: https://github.com/NabuCasa/sl-web-tools/releases/tag/0.12.1

This release fixes a bug with the baudrate bootloader trigger for the ZBT-2.