### PR TITLE
Bump sl-web-tools to 0.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "toolbox",
       "version": "0.0.0",
       "dependencies": {
-        "@nabucasa/sl-web-tools": "^0.12.1",
+        "@nabucasa/sl-web-tools": "^0.12.2",
         "improv-wifi-sdk": "^1.4.0"
       },
       "devDependencies": {
@@ -1289,9 +1289,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@nabucasa/sl-web-tools": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@nabucasa/sl-web-tools/-/sl-web-tools-0.12.1.tgz",
-      "integrity": "sha512-JLYOcMKEgSRWV9I3IOIYOc5XT692s8hUWWqkpEuzOwUTPNF9FqVuwVpsT5bKipDCTQ33t3/hkCZxo7i12rbbAw==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@nabucasa/sl-web-tools/-/sl-web-tools-0.12.2.tgz",
+      "integrity": "sha512-7pGY46fG9HJ/WKop7HqL4favx1YqmLsp89LejHKpjxOgFWvRPvEkplfGCtrom/Gtbqg1oenGkL6DiNIoKYC1aQ==",
       "license": "MIT",
       "dependencies": {
         "@material/mwc-button": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:check": "npx prettier --check src/**/*"
   },
   "dependencies": {
-    "@nabucasa/sl-web-tools": "^0.12.1",
+    "@nabucasa/sl-web-tools": "^0.12.2",
     "improv-wifi-sdk": "^1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes firmware detection after OpenThread firmware is installed by bundling a new release of `bellows`, fixing a write amplification bug when bellows tries to communicate with OpenThread RCP firmware.