### PR TITLE
Add ZWA-2 recover page to Vite rollup inputs

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -106,6 +106,10 @@ export default defineConfig({
           __dirname,
           'dist/home-assistant-connect-zwa-2/use-poe/index.html'
         ),
+        homeAssistantConnectZwa2Recover: resolve(
+          __dirname,
+          'dist/home-assistant-connect-zwa-2/recover/index.html'
+        ),
         homeAssistantConnectZbt1: resolve(
           __dirname,
           'dist/home-assistant-connect-zbt-1/index.html'


### PR DESCRIPTION
Add ZWA-2 recover page to Vite rollup inputs.
This fixes the broken [ZWA-2 recovery page](https://toolbox.openhomefoundation.org/home-assistant-connect-zwa-2/recover/). Reference with screenshot and error: https://github.com/OpenHomeFoundation/toolbox/pull/24#issuecomment-3984825945

Confirmed the fix locally with a "full build", as the issue does not manifest in dev mode – likely why it wasn't caught.