### PR TITLE
Probe router firmware for ZBT-2

### DIFF
--- a/public/assets/manifests/zbt2.json
+++ b/public/assets/manifests/zbt2.json
@@ -9,6 +9,9 @@
   }, {
     "protocol": "spinel",
     "baudrate": 460800
+  }, {
+    "protocol": "router",
+    "baudrate": 115200
   }],
   "usb_filters": [{
     "pid": 16385,


### PR DESCRIPTION
It's a little confusing when the ZBT-2 is shown as being in the recovery bootloader after flashing router firmware. This PR will detect the router firmware version number after flashing finishes.